### PR TITLE
WIP: runtime support for static virtual interface methods

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1143,9 +1143,9 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                 {
                     OPCODE actualOpcode = impGetNonPrefixOpcode(codeAddr, codeEndp);
 
-                    if (actualOpcode != CEE_CALLVIRT)
+                    if (actualOpcode != CEE_CALLVIRT && actualOpcode != CEE_CALL && actualOpcode != CEE_LDFTN)
                     {
-                        BADCODE("constrained. has to be followed by callvirt");
+                        BADCODE("constrained. has to be followed by callvirt, call or ldftn");
                     }
                 }
                 goto OBSERVE_OPCODE;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13862,7 +13862,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 JITDUMP(" %08X", resolvedToken.token);
 
-                eeGetCallInfo(&resolvedToken, nullptr /* constraint typeRef*/,
+                eeGetCallInfo(&resolvedToken,
+                              (prefixFlags & PREFIX_CONSTRAINED) ? &constrainedResolvedToken : nullptr,
                               addVerifyFlag(combine(CORINFO_CALLINFO_SECURITYCHECKS, CORINFO_CALLINFO_LDFTN)),
                               &callInfo);
 
@@ -14033,9 +14034,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 {
                     OPCODE actualOpcode = impGetNonPrefixOpcode(codeAddr, codeEndp);
-                    if (actualOpcode != CEE_CALLVIRT)
+                    if (actualOpcode != CEE_CALLVIRT && actualOpcode != CEE_CALL && actualOpcode != CEE_LDFTN)
                     {
-                        BADCODE("constrained. has to be followed by callvirt");
+                        BADCODE("constrained. has to be followed by callvirt, call or ldftn");
                     }
                 }
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -5118,7 +5118,7 @@ void CEEInfo::getCallInfo(
     TypeHandle exactType = TypeHandle(pResolvedToken->hClass);
 
     TypeHandle constrainedType;
-    if ((flags & CORINFO_CALLINFO_CALLVIRT) && (pConstrainedResolvedToken != NULL))
+    if (pConstrainedResolvedToken != NULL)
     {
         constrainedType = TypeHandle(pConstrainedResolvedToken->hClass);
     }

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -9176,6 +9176,7 @@ MethodDesc *
 MethodTable::ResolveVirtualStaticMethod(MethodDesc* pInterfaceMD)
 {
     // TODO
+    COMPlusThrow(kTypeLoadException, E_NOTIMPL);
 }
 
 //==========================================================================================

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -9171,6 +9171,14 @@ MethodDesc *MethodTable::GetDefaultConstructor(BOOL forceBoxedEntryPoint /* = FA
 }
 
 //==========================================================================================
+// Finds the (non-unboxing) MethodDesc that implements the interface virtual static method pInterfaceMD.
+MethodDesc *
+MethodTable::ResolveVirtualStaticMethod(MethodDesc* pInterfaceMD)
+{
+    // TODO
+}
+
+//==========================================================================================
 // Finds the (non-unboxing) MethodDesc that implements the interface method pInterfaceMD.
 //
 // Note our ability to resolve constraint methods is affected by the degree of code sharing we are
@@ -9188,6 +9196,11 @@ MethodTable::TryResolveConstraintMethodApprox(
         THROWS;
         GC_TRIGGERS;
     } CONTRACTL_END;
+
+    if (pInterfaceMD->IsStatic())
+    {
+        return ResolveVirtualStaticMethod(pInterfaceMD);
+    }
 
     // We can't resolve constraint calls effectively for reference types, and there's
     // not a lot of perf. benefit in doing it anyway.

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -1557,6 +1557,9 @@ public:
 
     inline WORD GetNumNonVirtualSlots();
 
+    inline BOOL HasVirtualStaticMethods() const;
+    inline void SetHasVirtualStaticMethods();
+
     inline WORD GetNumVirtuals()
     {
         LIMITED_METHOD_DAC_CONTRACT;
@@ -2275,6 +2278,9 @@ public:
     MethodDesc *GetMethodDescForComInterfaceMethod(MethodDesc *pItfMD, bool fNullOk);
 #endif // FEATURE_COMINTEROP
 
+
+    // Resolve virtual static interface method pInterfaceMD on this type.
+    MethodDesc *ResolveVirtualStaticMethod(MethodDesc* pInterfaceMD);
 
     // Try a partial resolve of the constraint call, up to generic code sharing.
     //
@@ -3655,7 +3661,7 @@ private:
         enum_flag_RequiresDispatchTokenFat  = 0x0200,
 
         enum_flag_HasCctor                  = 0x0400,
-        // enum_flag_unused                 = 0x0800,
+        enum_flag_HasVirtualStaticMethods   = 0x0800,
 
 #ifdef FEATURE_64BIT_ALIGNMENT
         enum_flag_RequiresAlign8            = 0x1000, // Type requires 8-byte alignment (only set on platforms that require this and don't get it implicitly)

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -542,6 +542,20 @@ inline INT32 MethodTable::MethodIterator::GetNumMethods() const
 }
 
 //==========================================================================================
+inline BOOL MethodTable::HasVirtualStaticMethods() const
+{
+    WRAPPER_NO_CONTRACT;
+    return GetFlag(enum_flag_HasVirtualStaticMethods);
+}
+
+//==========================================================================================
+inline void MethodTable::SetHasVirtualStaticMethods()
+{
+    WRAPPER_NO_CONTRACT;
+    return SetFlag(enum_flag_HasVirtualStaticMethods);
+}
+
+//==========================================================================================
 // Returns TRUE if it's valid to request data from the current position
 inline BOOL MethodTable::MethodIterator::IsValid() const
 {

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1180,17 +1180,17 @@ MethodTableBuilder::bmtInterfaceEntry::CreateSlotTable(
 
     CONSISTENCY_CHECK(m_pImplTable == NULL);
 
-    MethodTable *interfaceMT = GetInterfaceType()->GetMethodTable();
-    SLOT_INDEX cSlots = interfaceMT->GetNumVirtuals();
-    if (interfaceMT->HasVirtualStaticMethods())
-    {
-        cSlots += interfaceMT->GetNumNonVirtualSlots();
-    }
+    SLOT_INDEX cSlots = (SLOT_INDEX)GetInterfaceType()->GetMethodTable()->GetNumVirtuals();
     bmtInterfaceSlotImpl * pST = new (pStackingAllocator) bmtInterfaceSlotImpl[cSlots];
 
     MethodTable::MethodIterator it(GetInterfaceType()->GetMethodTable());
-    for (; m_cImplTable < cSlots; it.Next())
+    for (; it.IsValid(); it.Next())
     {
+        if (!it.IsVirtual())
+        {
+            break;
+        }
+
         bmtRTMethod * pCurMethod = new (pStackingAllocator)
             bmtRTMethod(GetInterfaceType(), it.GetDeclMethodDesc());
 
@@ -5628,6 +5628,7 @@ MethodTableBuilder::ProcessMethodImpls()
             // Non-virtual methods can only be classified as methodImpl when implementing
             // static virtual methods.
             CONSISTENCY_CHECK(IsMdStatic(it.Attrs()));
+            continue;
         }
 
         // If this method serves as the BODY of a MethodImpl specification, then

--- a/src/coreclr/vm/methodtablebuilder.h
+++ b/src/coreclr/vm/methodtablebuilder.h
@@ -1325,6 +1325,7 @@ private:
         bool fIsEnum;
         bool fNoSanityChecks;
         bool fSparse;                           // Set to true if a sparse interface is being used.
+        bool fHasVirtualStaticMethods;          // Set to true if the interface type declares virtual static methods.
 
         // Com Interop, ComWrapper classes extend from ComObject
         bool fIsComObjectType;                  // whether this class is an instance of ComObject class
@@ -1496,7 +1497,7 @@ private:
         AddNonVirtualMethod(bmtMDMethod * pMethod)
         {
             INDEBUG(SealVirtualSlotSection());
-            CONSISTENCY_CHECK(!IsMdVirtual(pMethod->GetDeclAttrs()));
+            CONSISTENCY_CHECK(!IsMdVirtual(pMethod->GetDeclAttrs()) || IsMdStatic(pMethod->GetDeclAttrs()));
             pMethod->SetSlotIndex(pSlotTable->GetSlotCount());
             if (!pSlotTable->AddMethodSlot(bmtMethodSlot(pMethod, pMethod)))
                 return false;
@@ -2984,7 +2985,8 @@ private:
                                 LoaderAllocator *pAllocator,
                                 BOOL isIFace,
                                 BOOL fDynamicStatics,
-                                BOOL fHasGenericsStaticsInfo
+                                BOOL fHasGenericsStaticsInfo,
+                                BOOL fHasVirtualStaticMethods
 #ifdef FEATURE_COMINTEROP
                                 , BOOL bHasDynamicInterfaceMap
 #endif


### PR DESCRIPTION
I have refactored my earlier changes based on the principle that the virtual static methods shouldn't go in the vtable. I'm now at the point of runtime lookup required by getCallInfo.

Thanks

Tomas