### PR TITLE
Handle generic methods

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -9246,7 +9246,7 @@ MethodTable::TryResolveVirtualStaticMethodOnThisType(MethodDesc* pInterfaceMD)
         {
             COMPlusThrow(kTypeLoadException, E_FAIL);
         }
-        if (pMethodDecl != pInterfaceMD)
+        if (!pMethodDecl->HasSameMethodDefAs(pInterfaceMD))
         {
             continue;
         }
@@ -9260,7 +9260,15 @@ MethodTable::TryResolveVirtualStaticMethodOnThisType(MethodDesc* pInterfaceMD)
         {
             COMPlusThrow(kTypeLoadException, E_FAIL);
         }
-        return pMethodImpl;
+
+        if (pInterfaceMD->HasMethodInstantiation())
+        {
+            return pMethodImpl->FindOrCreateAssociatedMethodDesc(pMethodImpl, this, FALSE, pInterfaceMD->GetMethodInstantiation(), TRUE);
+        }
+        else
+        {
+            return pMethodImpl;
+        }
     }
 
     return nullptr;


### PR DESCRIPTION
The generic instantiation is not part of the generic definition of the Method. Check to see that the MethodDef matches, and if it does, treat it as a match. To keep the correct instantiation in place, use FindOrCreateAssociatedMethodDesc to find the correct result.