### PR TITLE
Put embedGenericHandle in sync with constraint resolution (hacky)

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -5753,6 +5753,16 @@ void CEEInfo::getCallInfo(
         }
     }
 
+    // Propagate resolved constraint information to the pResolvedToken for subsequent use by embedGenericHandle
+    pResolvedToken->hMethod = pResult->hMethod;
+
+    if (exactType != th)
+    {
+        pResolvedToken->hClass = CORINFO_CLASS_HANDLE(exactType.GetMethodTable());
+        pResolvedToken->pTypeSpec = nullptr;
+        pResolvedToken->cbTypeSpec = 0;
+    }
+
     EE_TO_JIT_TRANSITION();
 }
 


### PR DESCRIPTION
As a proof of concept I am presenting the hotfix propagating
constraint resolution from getCallInfo to embedGenericHandle
by means of patching the pResolvedToken. It looks like a very
dirty thing to do but it fixes all crashes in the GenericContext
tests:

609 successes reported
891 failures reported
Expected: 100
Actual: 1
END EXECUTION - FAILED
FAILED

Thanks

Tomas