### PR TITLE
Exclude SVM test generators from test build

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13862,8 +13862,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 JITDUMP(" %08X", resolvedToken.token);
 
-                eeGetCallInfo(&resolvedToken,
-                              (prefixFlags & PREFIX_CONSTRAINED) ? &constrainedResolvedToken : nullptr,
+                eeGetCallInfo(&resolvedToken, (prefixFlags & PREFIX_CONSTRAINED) ? &constrainedResolvedToken : nullptr,
                               addVerifyFlag(combine(CORINFO_CALLINFO_SECURITYCHECKS, CORINFO_CALLINFO_LDFTN)),
                               &callInfo);
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8680,9 +8680,9 @@ CEEInfo::getMethodSigInternal(
         // Otherwise we would end up with two secret generic dictionary arguments (since the stub also provides one).
         //
         BOOL isCallSiteThatGoesThroughInstantiatingStub =
-            signatureKind == SK_VIRTUAL_CALLSITE &&
+            (signatureKind == SK_VIRTUAL_CALLSITE &&
             !ftn->IsStatic() &&
-            ftn->GetMethodTable()->IsInterface() ||
+            ftn->GetMethodTable()->IsInterface()) ||
             signatureKind == SK_STATIC_VIRTUAL_CODEPOINTER_CALLSITE;
         if (!isCallSiteThatGoesThroughInstantiatingStub)
             sigRet->callConv = (CorInfoCallConv) (sigRet->callConv | CORINFO_CALLCONV_PARAMTYPE);

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -5037,10 +5037,13 @@ MethodTableBuilder::ValidateMethods()
             }
         }
 
-        // Virtual static methods are not allowed.
-        if (IsMdStatic(it.Attrs()) && IsMdVirtual(it.Attrs()) && !IsInterface())
+        // Virtual static methods are only allowed on interfaces and they must be abstract.
+        if (IsMdStatic(it.Attrs()) && IsMdVirtual(it.Attrs()))
         {
-            BuildMethodTableThrowException(IDS_CLASSLOAD_STATICVIRTUAL, it.Token());
+            if (!IsInterface() || !IsMdAbstract(it.Attrs()))
+            {
+                BuildMethodTableThrowException(IDS_CLASSLOAD_STATICVIRTUAL, it.Token());
+            }
         }
     }
 }

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -14,6 +14,7 @@
       <DisabledProjects Include="$(TestRoot)GC\Performance\Framework\GCPerfTestFramework.csproj" />
       <DisabledProjects Include="$(TestRoot)Loader\classloader\generics\regressions\DD117522\Test.csproj" />
       <DisabledProjects Include="$(TestRoot)Loader\classloader\generics\GenericMethods\VSW491668.csproj" /> <!-- issue 5501 -->
+      <DisabledProjects Include="$(TestRoot)Loader\classloader\StaticVirtualMethods\**\generatetest.csproj" /> <!-- test generators -->
       <DisabledProjects Include="$(TestRoot)Performance\Scenario\JitBench\unofficial_dotnet\JitBench.csproj" /> <!-- no official build support for SDK-style netcoreapp2.0 projects -->
       <DisabledProjects Include="$(TestRoot)reflection\GenericAttribute\GenericAttributeTests.csproj" />
       <DisabledProjects Include="$(TestRoot)TestWrappers*\**\*.csproj" />


### PR DESCRIPTION
As the two test generators for TypeHierarchy and GenericContext
reside within the test source tree, we need to explicitly exclude
them from building as part of the test projects, otherwise test
project build fails due to asset path mismatches. An alternative
option would be to put the two test generator projects under
src\tests\Common where other test-related utilites reside and which
is globally excluded from test build.

Thanks

Tomas

P.S. I plan to create a no-merge PR against runtime main to get
initial CI results for the SVM test cases; locally I see just
a handful of failures in the negative tests.