### PR TITLE
Fix default interface method tests

### DIFF
--- a/src/coreclr/vm/genericdict.cpp
+++ b/src/coreclr/vm/genericdict.cpp
@@ -1396,7 +1396,7 @@ Dictionary::PopulateEntry(
                 // In such case we would need to box the value type before we can dispatch to the implementation.
                 // This would require us to make a "boxing stub". For now we leave the boxing stubs unimplemented.
                 // It's not clear if anyone would need them and the implementation complexity is not worth it at this time.
-                if (pResolvedMD->IsStatic() && !pResolvedMD->GetMethodTable()->IsValueType() && constraintType.GetMethodTable()->IsValueType())
+                if (!pResolvedMD->GetMethodTable()->IsValueType() && constraintType.GetMethodTable()->IsValueType())
                 {
                     SString assemblyName;
 


### PR DESCRIPTION
I have tracked down the failure in three default interface
constrained call tests to this added static-ness condition.
I have verified that all tests that have been passing previously
continue passing after removal of the check. I'm not sure what
its original purpose was but it looks quite weird as the code
comment alludes to instance boxing and that doesn't seem applicable
to static methods.

Thanks

Tomas